### PR TITLE
Include all directories marked with a .teamcode file

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,18 @@
 include ':FtcRobotController'
-include ':TeamCode'
+
+// Iterate through all team-provided directories and include them.
+FileCollection teamFiles = files { rootProject.projectDir.listFiles() }
+boolean teamDirectoryFound = false
+teamFiles.each { File teamDirectory ->
+    if (teamDirectory.isDirectory()) {
+        if (file(teamDirectory.name + '/.teamcode').exists()) {
+            include ':' + teamDirectory.name
+            teamDirectoryFound = true
+        }
+    }
+}
+
+// If no team-provided directories were found, include the TeamCode directory.
+if (!teamDirectoryFound) {
+    include ':TeamCode'
+}


### PR DESCRIPTION
In order to allow teams to better manage their code separate from the
ftc_app repository and without conflicts with the provided TeamCode
directory, include all directories at the base of ftc_app that are
marked with a .teamcode file.

This allows a team Android Studio to be set up by:

  1. Checking out or extracting ftc_app in any directory.
  2. Checking out the team's git repository inside of ftc_app.

Furthermore this allows much easier management of the ftc_app upstream
dependency by checking out ftc_app by branch e.g. vX.Y and updating the
branch simply by a new 'git checkout', without the possibility of any
file conflicts with the upstream repository being tracked.